### PR TITLE
Hi Jim. I noted the version of Ant (1.7.1.) making the build fail. It should actually not fail looking at the documentation of the get task... 

### DIFF
--- a/settings/install-ant-eclipse.xml
+++ b/settings/install-ant-eclipse.xml
@@ -11,7 +11,7 @@
     <target name="-download.ant-eclipse" depends="-ant-eclipse.jar.available" unless="skip.ant-eclipse.download">
 
         <mkdir dir="${ant-eclipse.dir}"/>
-        <get dest="${ant-eclipse.dir}" usetimestamp="true"
+        <get dest="${ant-eclipse.dir}/ant-eclipse-1.0.bin.tar.bz2" usetimestamp="true"
              src="http://downloads.sourceforge.net/project/ant-eclipse/ant-eclipse/1.0/ant-eclipse-1.0.bin.tar.bz2"/>
         <untar compression="bzip2" src="${ant-eclipse.dir}/ant-eclipse-1.0.bin.tar.bz2" dest="${ant-eclipse.dir}"/>
     </target>


### PR DESCRIPTION
...destination parameter.

This should definitely not be necessary, according to the documentation the destination is a directory or a file.
However, the build failed without this using ant 1.7.1
