### PR TITLE
Remove pollution-command from test that does not need it.

### DIFF
--- a/src/koan/java/org/neo4j/tutorial/Koan08d.java
+++ b/src/koan/java/org/neo4j/tutorial/Koan08d.java
@@ -59,7 +59,6 @@ public class Koan08d
     @Test
     public void shouldRemoveSalaryDataFromDoctorActors()
     {
-        polluteUniverseWithStarTrekData();
         ExecutionEngine engine = new ExecutionEngine( universe.getDatabase(), StringLogger.DEV_NULL );
         String cql = null;
 


### PR DESCRIPTION
The database does not need to be polluted with Star Trek references here.
