### PR TITLE
remove_snippets update

### DIFF
--- a/src/main/scripts/remove_snippets.sh
+++ b/src/main/scripts/remove_snippets.sh
@@ -17,4 +17,4 @@ case "$os_lwr" in
 esac
 
 find src/koan/java -name *.java -print | xargs sed -f src/main/scripts/remove_snippets.sed $dashi
-find src/koan/java -name *.deleteme -print | xargs rm
+find src/koan/java -name *.deleteme -delete


### PR DESCRIPTION
changed to -delete instead of 'xargs rm' because on my system it gives me an Error:
rm: missing operand
Try 'rm --help' for more information.

with -delete everything works fine for me (and should be faster)
