### PR TITLE
Fix Koan3 Wikipedia Test Assertion

### DIFF
--- a/src/koan/java/org/neo4j/tutorial/Koan3.java
+++ b/src/koan/java/org/neo4j/tutorial/Koan3.java
@@ -188,7 +188,8 @@ public class Koan3
 
         assertThat( iterator, containsOnlyWikipediaEntries( "http://en.wikipedia.org/wiki/Rory_Williams",
                 "http://en.wikipedia.org/wiki/Amy_Pond",
-                "http://en.wikipedia.org/wiki/River_Song_(Doctor_Who)" ) );
+                "http://en.wikipedia.org/wiki/River_Song_(Doctor_Who)",
+                "http://en.wikipedia.org/wiki/Clara_Oswald") );
 
     }
 

--- a/src/koan/java/org/neo4j/tutorial/Koan3.java
+++ b/src/koan/java/org/neo4j/tutorial/Koan3.java
@@ -168,7 +168,7 @@ public class Koan3
     }
 
     @Test
-    public void shouldReturnAnyWikpediaEntriesForCompanions()
+    public void shouldReturnAnyWikipediaEntriesForCompanions()
     {
         ExecutionEngine engine = new ExecutionEngine( universe.getDatabase(), DEV_NULL );
         String cql = null;


### PR DESCRIPTION
The test assertion for the wikipedia test in Koan3 was missing the reference to the Clara_Oswald wikipedia article. 
