### PR TITLE
Koan9 cypher query modifications

### DIFF
--- a/src/koan/java/org/neo4j/tutorial/Koan9.java
+++ b/src/koan/java/org/neo4j/tutorial/Koan9.java
@@ -43,7 +43,7 @@ public class Koan9
         String cql = null;
 
         // YOUR CODE GOES HERE
-		// Should find the prop part that is used in the most episodes
+        // Should find the prop part that is used in the most episodes
         // SNIPPET_START
 
         cql = "(episode:Episode)<-[:USED_IN]-(:Props)" +

--- a/src/koan/java/org/neo4j/tutorial/Koan9.java
+++ b/src/koan/java/org/neo4j/tutorial/Koan9.java
@@ -43,9 +43,10 @@ public class Koan9
         String cql = null;
 
         // YOUR CODE GOES HERE
+		// Should find the prop part that is used in the most episodes
         // SNIPPET_START
 
-        cql = "MATCH (daleks:Species {species: \"Dalek\"})-[:APPEARED_IN]->(episode:Episode)<-[:USED_IN]-(:Props)" +
+        cql = "(episode:Episode)<-[:USED_IN]-(:Props)" +
                 "<-[:MEMBER_OF]-(:Prop)-[:COMPOSED_OF]->(part:Part)-[:ORIGINAL_PROP]->(originalprop:Prop)" +
                 System.lineSeparator() +
                 "RETURN originalprop.prop, part.part, count(episode) ORDER BY count(episode) DESC LIMIT 1";


### PR DESCRIPTION
- Added explanatory comment above `SNIPPER_START`
- Removed the section from `MATCH` that matches the dalek species and its APPEARED_IN relationship. The name of the unit test implies that we just want to find the hardest working part, ie: the part that appeared in the most episodes. If the instruction was to find the part that appeared in the most episodes where there was a dalek that appeared in the episode, then this would be accurate. But the test as described in the title does not have anything to do with Daleks, so there should be no reason to include this in the sample solution query. Same result to the query either way - just appears that this is more accurate.
