### PR TITLE
Correcting typo in shouldRemoveSalaryDataFromDoctorActors

### DIFF
--- a/src/koan/java/org/neo4j/tutorial/Koan8.java
+++ b/src/koan/java/org/neo4j/tutorial/Koan8.java
@@ -84,7 +84,7 @@ public class Koan8
         engine.execute( cql );
 
         final ExecutionResult executionResult = engine.execute(
-                "MATCH (doctor:Character {character: 'Doctor'})<-[:PLAYED]-(actor:Character) " +
+                "MATCH (doctor:Character {character: 'Doctor'})<-[:PLAYED]-(actor:Actor) " +
                         "WHERE HAS (actor.salary) " +
                         "RETURN actor"
         );


### PR DESCRIPTION
The match query used for verifying the removal checks for a character that played the doctor. Since no characters have ever played the doctor, this assertion will always pass.
