### PR TITLE
upgrading 2.1.6 & universe caching

### DIFF
--- a/settings/path.xml
+++ b/settings/path.xml
@@ -3,8 +3,8 @@
 <project name="path" default="donothingToMakeAValidAntFile"
          basedir=".">
 
-  <property name="neo4j.version" value="2.1.4"/>
-
+  <property name="neo4j.version" value="2.1.6"/>
+  
   <property name="download.dir" location="downloads"/>
   <property name="neo4j.download.dir" location="${download.dir}/neo4j"/>
   <property name="neo4j.install.dir" location="${neo4j.download.dir}/neo4j-community-${neo4j.version}"/>

--- a/src/main/java/org/neo4j/tutorial/DoctorWhoUniverseGenerator.java
+++ b/src/main/java/org/neo4j/tutorial/DoctorWhoUniverseGenerator.java
@@ -60,8 +60,8 @@ public class DoctorWhoUniverseGenerator
 
     private boolean cachedDatabaseExists()
     {
-        return false; // for debugging
-//        return cachedCleanDatabaseDirectory.exists() && cachedCleanDatabaseDirectory.isDirectory();
+//        return false; // for debugging
+        return cachedCleanDatabaseDirectory.exists() && cachedCleanDatabaseDirectory.isDirectory();
     }
 
     private String copyDatabaseFromCachedDirectoryToTempDirectory() throws IOException


### PR DESCRIPTION
- upgrade to Neo4j 2.1.6
- enable universe caching by default to reduce test runtime 
